### PR TITLE
New release

### DIFF
--- a/inc/optimus.class.php
+++ b/inc/optimus.class.php
@@ -340,11 +340,11 @@ class Optimus
         return wp_parse_args(
             get_option('optimus'),
             array(
-                'copy_markers'        => 0,
-                'webp_convert'         => 0,
-                'keep_original'        => 0,
-                'secure_transport'    => 0,
-                'manual_optimize'    => 0
+                'copy_markers'      => 0,
+                'webp_convert'      => 0,
+                'keep_original'     => 0,
+                'secure_transport'  => 0,
+                'manual_optimize'   => 0
             )
         );
     }

--- a/inc/optimus.class.php
+++ b/inc/optimus.class.php
@@ -40,20 +40,6 @@ class Optimus
         /* Get plugin options */
         $options = Optimus::get_options();
 
-        /* Check if manual optimization is enabled */
-        if ( ! $options['manual_optimize'] ) {
-            /* Fire! */
-            add_filter(
-                'wp_generate_attachment_metadata',
-                array(
-                    'Optimus_Request',
-                    'optimize_upload_images'
-                ),
-                10,
-                2
-            );
-        }
-
         /* Remove converted files */
         add_filter(
             'wp_delete_file',

--- a/inc/optimus_management.class.php
+++ b/inc/optimus_management.class.php
@@ -115,7 +115,7 @@ class Optimus_Management
 
         echo '<div class="wrap" id="optimus-bulk-optimizer">';
         echo '<h2>' . __("Optimus Bulk Optimizer", "optimus") . '</h2>';
-        if (empty($_POST['optimus-bulk-optimizer']) && empty($_GET['ids'])) {
+        if ((empty($_POST['optimus-bulk-optimizer']) && empty($_GET['ids'])) || $count == 0) {
             echo '<p>' . __("The Optimus bulk optimizer compresses all images that have not yet been compressed in your WordPress media library.", "optimus") . '</p>';
 
             if ( Optimus_HQ::is_locked() ) {

--- a/inc/optimus_management.class.php
+++ b/inc/optimus_management.class.php
@@ -76,6 +76,13 @@ class Optimus_Management
         /* Get plugin options */
         $options = Optimus::get_options();
 
+        /* Supported image types */
+        $imageTypes = ['jpeg', 'png'];
+        foreach ($imageTypes as &$imageType) {
+           $imageType = "$wpdb->posts.post_mime_type = 'image/$imageType'"; 
+        }
+        $queryImageTypes = "(". join(" OR ", $imageTypes) .")";
+
         /* Check if images are already optimized */
         if ( $options['webp_convert'] ) {
             $optimus_query = '%optimus%webp";i:1%';
@@ -97,6 +104,7 @@ class Optimus_Management
             WHERE $wpdb->posts.ID = $wpdb->postmeta.post_id
                 AND $wpdb->posts.post_type = 'attachment'
                 AND $wpdb->posts.post_mime_type LIKE 'image/%'
+                AND $queryImageTypes
                 AND $wpdb->postmeta.meta_key = '_wp_attachment_metadata'
                 AND $wpdb->postmeta.meta_value NOT LIKE '$optimus_query'
                 $id_query

--- a/inc/optimus_request.class.php
+++ b/inc/optimus_request.class.php
@@ -586,9 +586,9 @@ class Optimus_Request
 
             /* Optimus HQ */
             true => array(
-                'image/jpeg' => 5000 * 1024,
-                'image/webp' => 5000 * 1024,
-                'image/png'  => 5000 * 1024
+                'image/jpeg' => 10000 * 1024,
+                'image/webp' => 10000 * 1024,
+                'image/png'  => 10000 * 1024
             )
         );
 

--- a/inc/optimus_settings.class.php
+++ b/inc/optimus_settings.class.php
@@ -126,7 +126,7 @@ class Optimus_Settings
 
                     <tr valign="top">
                         <th scope="row">
-                            <?php _e("Original images", "optimus"); ?>
+                            <?php _e("Ignore original images", "optimus"); ?>
                         </th>
                         <td>
                             <fieldset>
@@ -144,7 +144,7 @@ class Optimus_Settings
 
                     <tr valign="top">
                         <th scope="row">
-                            <?php _e("Image metadata", "optimus"); ?>
+                            <?php _e("Keep image metadata", "optimus"); ?>
                         </th>
                         <td>
                             <fieldset>
@@ -198,7 +198,7 @@ class Optimus_Settings
 
                     <tr valign="top">
                         <th scope="row">
-                            <?php _e("Optimize during upload", "optimus"); ?>
+                            <?php _e("Manual optimization", "optimus"); ?>
                         </th>
                         <td>
                             <fieldset>

--- a/inc/optimus_settings.class.php
+++ b/inc/optimus_settings.class.php
@@ -149,7 +149,7 @@ class Optimus_Settings
                         <td>
                             <fieldset>
                                 <label for="optimus_copy_markers">
-                                    <input type="checkbox" name="optimus[copy_markers]" id="optimus_copy_markers" value="1" <?php checked(1, $options['copy_markers']) ?> />
+                                    <input type="checkbox" name="optimus[copy_markers]" id="optimus_copy_markers" value="1" <?php checked(1, $options['copy_markers']); if ( Optimus_HQ::is_locked() ) { _e("onclick=\"return false;\" disabled=\"disabled\""); } ?> />
                                     <?php _e("No deletion of image metadata", "optimus"); ?>
                                 </label>
 
@@ -167,7 +167,7 @@ class Optimus_Settings
                         <td>
                             <fieldset>
                                 <label for="optimus_webp_convert">
-                                    <input type="checkbox" name="optimus[webp_convert]" id="optimus_webp_convert" value="1" <?php checked(1, $options['webp_convert']) ?> />
+                                    <input type="checkbox" name="optimus[webp_convert]" id="optimus_webp_convert" value="1" <?php checked(1, $options['webp_convert']); if ( Optimus_HQ::is_locked() ) { _e("onclick=\"return false;\" disabled=\"disabled\""); }  ?> />
                                     <?php _e("Creation of WebP files", "optimus"); ?>
                                 </label>
 
@@ -185,7 +185,7 @@ class Optimus_Settings
                         <td>
                             <fieldset>
                                 <label for="optimus_secure_transport">
-                                    <input type="checkbox" name="optimus[secure_transport]" id="optimus_secure_transport" value="1" <?php checked(1, $options['secure_transport']) ?> />
+                                    <input type="checkbox" name="optimus[secure_transport]" id="optimus_secure_transport" value="1" <?php checked(1, $options['secure_transport']); if ( Optimus_HQ::is_locked() ) { _e("onclick=\"return false;\" disabled=\"disabled\""); }  ?> />
                                     <?php _e("Transfer images using TLS encryption", "optimus"); ?>
                                 </label>
 

--- a/inc/optimus_settings.class.php
+++ b/inc/optimus_settings.class.php
@@ -39,7 +39,7 @@ class Optimus_Settings
     * Valisierung der Optionsseite
     *
     * @since   1.0.0
-    * @change  1.4.0
+    * @change  1.5.0
     *
     * @param   array  $data  Array mit Formularwerten
     * @return  array         Array mit geprüften Werten
@@ -48,11 +48,11 @@ class Optimus_Settings
     public static function validate_settings($data)
     {
         return array(
-            'copy_markers'        => (int)(!empty($data['copy_markers'])),
-            'webp_convert'        => (int)(!empty($data['webp_convert'])),
-            'keep_original'        => (int)(!empty($data['keep_original'])),
-            'secure_transport'    => (int)(!empty($data['secure_transport'])),
-            'manual_optimize'    => (int)(!empty($data['manual_optimize']))
+            'copy_markers'      => (int)(!empty($data['copy_markers'])),
+            'webp_convert'      => (int)(!empty($data['webp_convert'])),
+            'keep_original'     => (int)(!empty($data['keep_original'])),
+            'secure_transport'  => (int)(!empty($data['secure_transport'])),
+            'manual_optimize'   => (int)(!empty($data['manual_optimize']))
         );
     }
 

--- a/optimus.php
+++ b/optimus.php
@@ -104,7 +104,6 @@ spl_autoload_register('optimus_autoload');
 $options = Optimus::get_options();
 
 if ( ! $options['manual_optimize'] ) {
-    error_log("optim new");
     add_action('wp_generate_attachment_metadata',
         array(
             'Optimus_Request',

--- a/optimus.php
+++ b/optimus.php
@@ -7,7 +7,7 @@ Author: KeyCDN
 Author URI: https://www.keycdn.com
 Plugin URI: https://optimus.io
 License: GPLv2 or later
-Version: 1.4.9
+Version: 1.5.0
 */
 
 /*

--- a/optimus.php
+++ b/optimus.php
@@ -100,6 +100,21 @@ register_activation_hook(
 /* Autoload Init */
 spl_autoload_register('optimus_autoload');
 
+/* Check if manual optimization is enabled, hook in if not */
+$options = Optimus::get_options();
+
+if ( ! $options['manual_optimize'] ) {
+    error_log("optim new");
+    add_action('wp_generate_attachment_metadata',
+        array(
+            'Optimus_Request',
+            'optimize_upload_images',
+        ),
+        10,
+        2
+    );
+}
+
 /* Autoload Funktion */
 function optimus_autoload($class) {
     if ( in_array($class, array('Optimus', 'Optimus_HQ', 'Optimus_Management', 'Optimus_Settings', 'Optimus_Media', 'Optimus_Request')) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,13 @@ Optimus supports the conversion of images to the new [*WebP* image format](https
 
 == Changelog ==
 
+= 1.5.0 =
+* Unsupported image types are now gracefully skipped
+* Renamed setting names and greyed out inapplicable settings to avoid confusion
+* Increased size limit for Optimus HQ to 10MB
+* Licences can now easily be extended
+* Optimize images uploaded through the REST API
+
 = 1.4.9 =
 * Formatting updates
 


### PR DESCRIPTION
- Unsupported image types are now gracefully skipped
- Renamed setting names and greyed out inapplicable settings to avoid confusion
- Increased size limit for Optimus HQ to 10MB
- Licences can now easily be extended
- Optimize images uploaded through the REST API