### PR TITLE
Fix JS error on bulk optimizing images

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -21,7 +21,7 @@
             row.find('.bar').css('width', '100%')
             row.find('.percent').html(data.info)
             row.find('.progress').attr("title", data.info)
-        } else if (typeof data.optimus.quantity != "undefined") {
+        } else if (typeof data.optimus != "undefined" && typeof data.optimus.quantity != "undefined") {
             if (data.optimus.quantity < 100) {
                 status.addClass('partial')
                 row.find('.bar').css('width', data.optimus.quantity + '%')


### PR DESCRIPTION
Sometimes Optimus HQ hangs when bulk optimizing images, especially when processing some png files. If the server returns an error, the javascript gets stuck because of some missing conditions in the else if clause.